### PR TITLE
Add IR based JIT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #    Copyright (c) 2015, 2016 Grigory Rechistov. All rights reserved.
 #
 
-CFLAGS=-std=c11 -O2 -Wextra -Werror -gdwarf-3
+CFLAGS=-std=c11 -O0 -g -Wextra -Werror -gdwarf-3
 LDFLAGS = -lm
 
 COMMON_SRC = common.c

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMMON_SRC = common.c
 COMMON_OBJ := $(COMMON_SRC:.c=.o)
 COMMON_HEADERS = common.h
 
-ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native jited_ir
+ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native jited_ir jited_ir_stack
 
 # Must be the first target for the magic below to work
 all: $(ALL)
@@ -115,4 +115,10 @@ jited_ir.o: jited_ir.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -c $<
 
 jited_ir: jited_ir.o
+	$(CC) $^ -lir -lcapstone -lm -o $@
+
+jited_ir_stack.o: jited_ir.c
+	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -c $<
+
+jited_ir_stack: jited_ir_stack.o
 	$(CC) $^ -lir -lcapstone -lm -o $@

--- a/Makefile
+++ b/Makefile
@@ -44,46 +44,46 @@ $(ALL): $(COMMON_OBJ)
 # Note that some of them use customized CFLAGS
 
 switched: switched.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 threaded: CFLAGS += -fno-gcse -fno-function-cse -fno-thread-jumps -fno-cse-follow-jumps -fno-crossjumping -fno-cse-skip-blocks -fomit-frame-pointer
 threaded: threaded.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 predecoded: predecoded.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 tailrecursive: CFLAGS += -foptimize-sibling-calls
 tailrecursive: tailrecursive.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 asmoptll: asmoptll.o
 	$(CC) -g -pg -c $< -o $@
 
 asmopt: CFLAGS += -foptimize-sibling-calls
 asmopt: asmoptll.o asmopt.o
-	$(CC) -g -pg $^ -lm -o $@
+	$(CC) -g -pg $^ $(LDFLAGS) -o $@
 
 prof:
 	gprof -b asmopt gmon.out
 
 threaded-cached: CFLAGS += -fno-gcse -fno-thread-jumps -fno-cse-follow-jumps -fno-crossjumping -fno-cse-skip-blocks -fomit-frame-pointer
 threaded-cached: threaded-cached.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 subroutined: subroutined.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 translated: CFLAGS += -std=gnu11
 translated: translated.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 translated-inline: CFLAGS += -std=gnu11
 translated-inline: translated-inline.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 native: native.o
-	$(CC) $^ -lm -o $@
+	$(CC) $^ $(LDFLAGS) -o $@
 
 ########################
 ### Maintainance targets
@@ -116,22 +116,22 @@ jited_ir.o: jited_ir.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -c $<
 
 jited_ir: jited_ir.o
-	$(CC) $^ -lir -lcapstone -lm -o $@
+	$(CC) $^ -lir -lcapstone $(LDFLAGS) -o $@
 
 jited_ir_stack.o: jited_ir.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -o $@ -c $<
 
 jited_ir_stack: jited_ir_stack.o
-	$(CC) $^ -lir -lcapstone -lm -o $@
+	$(CC) $^ -lir -lcapstone $(LDFLAGS) -o $@
 
 jited_ir_var.o: jited_ir.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -DJIT_USE_VARS -o $@ -c $<
 
 jited_ir_var: jited_ir_var.o
-	$(CC) $^ -lir -lcapstone -lm -o $@
+	$(CC) $^ -lir -lcapstone $(LDFLAGS) -o $@
 
 jited_ir_ssa.o: jited_ir.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -DJIT_USE_SSA -o $@ -c $<
 
 jited_ir_ssa: jited_ir_ssa.o
-	$(CC) $^ -lir -lcapstone -lm -o $@
+	$(CC) $^ -lir -lcapstone $(LDFLAGS) -o $@

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMMON_SRC = common.c
 COMMON_OBJ := $(COMMON_SRC:.c=.o)
 COMMON_HEADERS = common.h
 
-ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native
+ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native jited_ir
 
 # Must be the first target for the magic below to work
 all: $(ALL)
@@ -110,3 +110,9 @@ threaded-notune: threaded.o
 # This will crash with stack overflow
 tailrecursive-noopt: CFLAGS += -O0 -fno-optimize-sibling-calls
 tailrecursive-noopt: tailrecursive.o
+
+jited_ir.o: jited_ir.c
+	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -c $<
+
+jited_ir: jited_ir.o
+	$(CC) $^ -lir -lcapstone -lm -o $@

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ jited_ir: jited_ir.o
 	$(CC) $^ -lir -lcapstone -lm -o $@
 
 jited_ir_stack.o: jited_ir.c
-	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -c $<
+	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -o $@ -c $<
 
 jited_ir_stack: jited_ir_stack.o
 	$(CC) $^ -lir -lcapstone -lm -o $@

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ COMMON_SRC = common.c
 COMMON_OBJ := $(COMMON_SRC:.c=.o)
 COMMON_HEADERS = common.h
 
-ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native jited_ir jited_ir_stack
+ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native jited_ir jited_ir_stack jited_ir_var
 
 # Must be the first target for the magic below to work
 all: $(ALL)
@@ -121,4 +121,10 @@ jited_ir_stack.o: jited_ir.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -o $@ -c $<
 
 jited_ir_stack: jited_ir_stack.o
+	$(CC) $^ -lir -lcapstone -lm -o $@
+
+jited_ir_var.o: jited_ir.c
+	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -DJIT_USE_VARS -O0 -g -o $@ -c $<
+
+jited_ir_var: jited_ir_var.o
 	$(CC) $^ -lir -lcapstone -lm -o $@

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,8 @@ COMMON_SRC = common.c
 COMMON_OBJ := $(COMMON_SRC:.c=.o)
 COMMON_HEADERS = common.h
 
-ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native jited_ir jited_ir_stack jited_ir_var
+ALL = switched threaded predecoded subroutined threaded-cached tailrecursive asmopt translated native \
+      jited_ir jited_ir_stack jited_ir_var jited_ir_ssa
 
 # Must be the first target for the magic below to work
 all: $(ALL)
@@ -127,4 +128,10 @@ jited_ir_var.o: jited_ir.c
 	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -DJIT_USE_VARS -o $@ -c $<
 
 jited_ir_var: jited_ir_var.o
+	$(CC) $^ -lir -lcapstone -lm -o $@
+
+jited_ir_ssa.o: jited_ir.c
+	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -DJIT_USE_SSA -o $@ -c $<
+
+jited_ir_ssa: jited_ir_ssa.o
 	$(CC) $^ -lir -lcapstone -lm -o $@

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ jited_ir_stack: jited_ir_stack.o
 	$(CC) $^ -lir -lcapstone -lm -o $@
 
 jited_ir_var.o: jited_ir.c
-	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -DJIT_USE_VARS -O0 -g -o $@ -c $<
+	$(CC) $(DEPFLAGS) $(CFLAGS) $(CPPFLAGS) -DJIT_RESOLVE_STACK -DJIT_USE_VARS -o $@ -c $<
 
 jited_ir_var: jited_ir_var.o
 	$(CC) $^ -lir -lcapstone -lm -o $@

--- a/common.c
+++ b/common.c
@@ -35,6 +35,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 
 #include "common.h"
 
+int debug = 0;
+
 /* Program to print all prime numbers < 10000 */
 const Instr_t Primes[PROGRAM_SIZE] = {
     Instr_Push, 100000, // nmax (maximal number to test)
@@ -198,6 +200,8 @@ uint64_t parse_args(int argc, char** argv) {
     for (int i = 1; i < argc; ++i) {
         if (!strcmp(argv[i], "--help"))
             report_usage_and_exit(argv[0], 0);
+        if (!strcmp(argv[i], "--debug"))
+            debug = 1;
         else if (!strncmp(argv[i], steplimit_opt, strlen(steplimit_opt))) {
             char *endptr = NULL;
             steplimit = strtoll(argv[i] + strlen(steplimit_opt), &endptr, 10);

--- a/common.h
+++ b/common.h
@@ -33,6 +33,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 #ifndef COMMON_H_
 #define COMMON_H_
 
+extern int debug;
+
 /* Instruction Set Architecture:
    opcodes and arguments for individual instructions.
    Those marked with "imm" use the next machine word

--- a/jited_ir.c
+++ b/jited_ir.c
@@ -746,6 +746,17 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
         ir_STORE(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, state)), ir_CONST_I32(Cpu_Break));
         ir_RETURN(IR_VOID);
     }
+
+#ifdef JIT_RESOLVE_STACK
+# if defined(JIT_USE_SSA)
+    free(jit->ssa_vars);
+    free(jit->incomplete_phis);
+# elif defined(JIT_USE_SSA)
+    free(jit->vars);
+# endif
+    free(jit->bb_sp);
+#endif
+    free(jit->labels);
 }
 
 int main(int argc, char **argv) {

--- a/jited_ir.c
+++ b/jited_ir.c
@@ -1,0 +1,440 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <limits.h>
+#include <math.h>
+
+#include "common.h"
+
+#include <stddef.h>
+#include "ir.h"
+#include "ir_builder.h"
+
+#define ir_CONST_STR(str) ir_const_str(ctx, ir_str(ctx, str))
+
+static inline decode_t decode_at_address(const Instr_t* prog, uint32_t addr) {
+    assert(addr < PROGRAM_SIZE);
+    decode_t result = {0};
+    Instr_t raw_instr = prog[addr];
+    result.opcode = raw_instr;
+    switch (raw_instr) {
+    case Instr_Nop:
+    case Instr_Halt:
+    case Instr_Print:
+    case Instr_Swap:
+    case Instr_Dup:
+    case Instr_Inc:
+    case Instr_Add:
+    case Instr_Sub:
+    case Instr_Mul:
+    case Instr_Rand:
+    case Instr_Dec:
+    case Instr_Drop:
+    case Instr_Over:
+    case Instr_Mod:
+    case Instr_And:
+    case Instr_Or:
+    case Instr_Xor:
+    case Instr_SHL:
+    case Instr_SHR:
+    case Instr_Rot:
+    case Instr_SQRT:
+    case Instr_Pick:
+        result.length = 1;
+        break;
+    case Instr_Push:
+    case Instr_JNE:
+    case Instr_JE:
+    case Instr_Jump:
+        result.length = 2;
+        if (!(addr+1 < PROGRAM_SIZE)) {
+            result.length = 1;
+            result.opcode = Instr_Break;
+            break;
+        }
+        result.immediate = (int32_t)prog[addr+1];
+        break;
+    case Instr_Break:
+    default: /* Undefined instructions equal to Break */
+        result.length = 1;
+        result.opcode = Instr_Break;
+        break;
+    }
+    return result;
+}
+
+/*** Service routines ***/
+#define BAIL_ON_ERROR() if (cpu.state != Cpu_Running) break;
+
+static void jit_push(ir_ctx *ctx, ir_ref cpu, ir_ref *stack_overflow, ir_ref v) {
+    // JIT: if (pcpu->sp >= STACK_CAPACITY-1) {
+    ir_ref sp_addr = ir_ADD_OFFSET(cpu, offsetof(cpu_t, sp));
+    ir_ref sp = ir_LOAD_I32(sp_addr);
+    ir_ref if_overflow = ir_IF(ir_GE(sp, ir_CONST_I32(STACK_CAPACITY-1)));
+
+    ir_IF_TRUE_cold(if_overflow);
+    ir_END_list(*stack_overflow);
+
+    ir_IF_FALSE(if_overflow);
+
+    // JIT: pcpu->stack[++pcpu->sp] = v;
+    sp = ir_ADD_I32(sp, ir_CONST_I32(1));
+    ir_STORE(sp_addr, sp);
+    ir_STORE(ir_ADD_I32(ir_ADD_OFFSET(cpu, offsetof(cpu_t, stack)),
+            ir_MUL_I32(sp, ir_CONST_I32(sizeof(uint32_t)))), v);
+}
+
+static ir_ref jit_pop(ir_ctx *ctx, ir_ref cpu, ir_ref *stack_underflow) {
+    // JIT: if (pcpu->sp < 0) {
+    ir_ref sp_addr = ir_ADD_OFFSET(cpu, offsetof(cpu_t, sp));
+    ir_ref sp = ir_LOAD_I32(sp_addr);
+    ir_ref if_underflow = ir_IF(ir_LT(sp, ir_CONST_I32(0)));
+
+    ir_IF_TRUE_cold(if_underflow);
+    ir_END_list(*stack_underflow);
+
+    ir_IF_FALSE(if_underflow);
+
+    //JIT: pcpu->stack[pcpu->sp--];
+    ir_ref ret = ir_LOAD_I32(ir_ADD_I32(ir_ADD_OFFSET(cpu, offsetof(cpu_t, stack)),
+            ir_MUL_I32(sp, ir_CONST_I32(sizeof(uint32_t)))));
+    sp = ir_SUB_I32(sp, ir_CONST_I32(1));
+    ir_STORE(sp_addr, sp);
+
+    return ret;
+}
+
+static ir_ref jit_pick(ir_ctx *ctx, ir_ref cpu, ir_ref *stack_bound, ir_ref pos) {
+    // JIT: if (pcpu->sp - 1 < pos) {
+    ir_ref sp = ir_LOAD_I32(ir_ADD_OFFSET(cpu, offsetof(cpu_t, sp)));
+    ir_ref if_out = ir_IF(ir_LT(ir_SUB_U32(sp, ir_CONST_U32(1)), pos));
+
+    ir_IF_TRUE_cold(if_out);
+    ir_END_list(*stack_bound);
+
+    ir_IF_FALSE(if_out);
+    // JIT: pcpu->stack[pcpu->sp - pos];
+    return ir_LOAD_I32(ir_ADD_I32(ir_ADD_OFFSET(cpu, offsetof(cpu_t, stack)),
+            ir_MUL_I32(ir_SUB_I32(sp, pos), ir_CONST_I32(sizeof(uint32_t)))));
+}
+
+typedef struct _jit_label {
+    ir_ref inputs; /* number of input edges */
+    ir_ref merge;  /* reference of MERGE or "list" of forward inputs */
+} jit_label;
+
+static void jit_goto_backward(ir_ctx *ctx, jit_label *label) {
+    ir_set_op(ctx, label->merge, ++label->inputs, ir_END());
+}
+
+static void jit_goto_forward(ir_ctx *ctx, jit_label *label) {
+    ir_END_list(label->merge);
+}
+
+static void jit_program(ir_ctx *ctx, const Instr_t *prog, int len) {
+    assert(prog);
+    ir_ref stack_overflow = IR_UNUSED;
+    ir_ref stack_underflow = IR_UNUSED;
+    ir_ref stack_bound = IR_UNUSED;
+    jit_label *labels = calloc(len, sizeof(jit_label));
+
+    /* mark goto targets */
+    for (int i=0; i < len;) {
+        decode_t decoded = decode_at_address(prog, i);
+
+        i += decoded.length;
+        switch(decoded.opcode) {
+        case Instr_JE:
+        case Instr_JNE:
+        case Instr_Jump:
+            labels[i + decoded.immediate].inputs++;
+            break;
+        }
+    }
+
+    ir_START();
+    ir_ref tmp1, tmp2, tmp3;
+    ir_ref cpu = ir_PARAM(IR_ADDR, "cpu", 1);
+    ir_ref printf_func =
+        ir_const_func(ctx, ir_str(ctx, "printf"), ir_proto_1(ctx, IR_I32, IR_VARARG_FUNC, IR_ADDR));
+    ir_ref rand_func =
+        ir_const_func(ctx, ir_str(ctx, "rand"), ir_proto_0(ctx, IR_I32, 0));
+    ir_ref sqrt_func =
+        ir_const_func(ctx, ir_str(ctx, "sqrt"), ir_proto_1(ctx, IR_DOUBLE, IR_BUILTIN_FUNC, IR_DOUBLE));
+
+    for (int i=0; i < len;) {
+        decode_t decoded = decode_at_address(prog, i);
+
+        if (labels[i].inputs > 0) {
+            assert(!ctx->control);
+            if (labels[i].inputs == 1) {
+                tmp1 = ir_emit1(ctx, IR_BEGIN, IR_UNUSED);
+            } else {
+                tmp1 = ir_emit_N(ctx, IR_MERGE, labels[i].inputs);
+            }
+            tmp2 = 0;
+            tmp3 = labels[i].merge;
+            labels[i].merge = ctx->control = tmp1;
+
+            while (tmp3) {
+                /* Store forward GOTOs into MERGE */
+                tmp2++;
+                assert(tmp2 <= labels[i].inputs);
+                ir_set_op(ctx, tmp1, tmp2, tmp3);
+                ir_insn *insn = &ctx->ir_base[tmp3];
+                assert(insn->op == IR_END);
+                tmp3 = insn->op2;
+                insn->op2 = IR_UNUSED;
+            }
+            labels[i].inputs = tmp2;
+        }
+
+        i += decoded.length;
+
+        switch(decoded.opcode) {
+        case Instr_Nop:
+            /* Do nothing */
+            break;
+        case Instr_Halt:
+            // JIT: cpu.state = Cpu_Halted;
+            ir_STORE(ir_ADD_OFFSET(cpu, offsetof(cpu_t, state)), ir_CONST_I32(Cpu_Halted));
+            ir_RETURN(IR_VOID);
+            break;
+        case Instr_Push:
+            jit_push(ctx, cpu, &stack_overflow, ir_CONST_U32(decoded.immediate));
+            break;
+        case Instr_Print:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            ir_CALL_2(IR_VOID, printf_func, ir_CONST_STR("[%d]\n"), tmp1);
+            break;
+        case Instr_Swap:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            jit_push(ctx, cpu, &stack_overflow, tmp2);
+            break;
+        case Instr_Dup:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            break;
+        case Instr_Over:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, tmp2);
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            jit_push(ctx, cpu, &stack_overflow, tmp2);
+            break;
+        case Instr_Inc:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_ADD_U32(tmp1, ir_CONST_U32(1)));
+            break;
+        case Instr_Add:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_ADD_U32(tmp1, tmp2));
+            break;
+        case Instr_Sub:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_SUB_U32(tmp1, tmp2));
+            break;
+        case Instr_Mod:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            // JIT if (tmp2 == 0)
+            tmp3 = ir_IF(ir_EQ(tmp2, ir_CONST_U32(0)));
+
+            ir_IF_TRUE_cold(tmp3);
+            // JIT: printf("Division by zero\n");
+            ir_CALL_1(IR_VOID, printf_func, ir_CONST_STR("Division by zero\n"));
+            // JIT: pcpu->state = Cpu_Break;
+            ir_STORE(ir_ADD_OFFSET(cpu, offsetof(cpu_t, state)), ir_CONST_I32(Cpu_Break));
+            ir_RETURN(IR_VOID);
+
+            ir_IF_FALSE(tmp3);
+            jit_push(ctx, cpu, &stack_overflow, ir_MOD_U32(tmp1, tmp2));
+            break;
+
+        case Instr_Mul:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_MUL_U32(tmp1, tmp2));
+            break;
+        case Instr_Rand:
+            tmp1 = ir_CALL(IR_I32, rand_func);
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            break;
+        case Instr_Dec:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_SUB_U32(tmp1, ir_CONST_U32(1)));
+            break;
+        case Instr_Drop:
+            (void)jit_pop(ctx, cpu, &stack_underflow);
+            break;
+        case Instr_JE:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            // JIT: if (tmp1 == 0)
+            tmp3 = ir_IF(ir_EQ(tmp1, ir_CONST_U32(0)));
+            ir_IF_TRUE(tmp3);
+            if (decoded.immediate < -decoded.length) {
+                jit_goto_backward(ctx, &labels[i + decoded.immediate]);
+            } else {
+                jit_goto_forward(ctx, &labels[i + decoded.immediate]);
+            }
+            ir_IF_FALSE(tmp3);
+            break;
+        case Instr_JNE:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            // JIT: if (tmp1 == 0)
+            tmp3 = ir_IF(ir_NE(tmp1, ir_CONST_U32(0)));
+            ir_IF_TRUE(tmp3);
+            if (decoded.immediate < -decoded.length) {
+                jit_goto_backward(ctx, &labels[i + decoded.immediate]);
+            } else {
+                jit_goto_forward(ctx, &labels[i + decoded.immediate]);
+            }
+            ir_IF_FALSE(tmp3);
+            break;
+        case Instr_Jump:
+            if (decoded.immediate < -decoded.length) {
+                jit_goto_backward(ctx, &labels[i + decoded.immediate]);
+            } else {
+                jit_goto_forward(ctx, &labels[i + decoded.immediate]);
+            }
+            break;
+        case Instr_And:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_AND_U32(tmp1, tmp2));
+            break;
+        case Instr_Or:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_OR_U32(tmp1, tmp2));
+            break;
+        case Instr_Xor:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_XOR_U32(tmp1, tmp2));
+            break;
+        case Instr_SHL:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_SHL_U32(tmp1, tmp2));
+            break;
+        case Instr_SHR:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, ir_SHR_U32(tmp1, tmp2));
+            break;
+        case Instr_Rot:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp2 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp3 = jit_pop(ctx, cpu, &stack_underflow);
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            jit_push(ctx, cpu, &stack_overflow, tmp3);
+            jit_push(ctx, cpu, &stack_overflow, tmp2);
+            break;
+        case Instr_SQRT:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp1 = ir_FP2U32(ir_CALL_1(IR_DOUBLE, sqrt_func, ir_INT2D(tmp1)));
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            break;
+        case Instr_Pick:
+            tmp1 = jit_pop(ctx, cpu, &stack_underflow);
+            tmp1 = jit_pick(ctx, cpu, &stack_bound, tmp1);
+            jit_push(ctx, cpu, &stack_overflow, tmp1);
+            break;
+        case Instr_Break:
+            if (ctx->control) {
+                // JIT: pcpu->state = Cpu_Break;
+                ir_STORE(ir_ADD_OFFSET(cpu, offsetof(cpu_t, state)), ir_CONST_I32(Cpu_Break));
+                ir_RETURN(IR_VOID);
+            }
+            i = len;
+            break;
+        default:
+            assert(0 && "Unsupported instruction");
+            break;
+        }
+        if (i < len && labels[i].inputs > 0 && decoded.opcode != Instr_Jump) {
+            labels[i].inputs++;
+            jit_goto_forward(ctx, &labels[i]);
+        }
+    }
+
+    if (stack_overflow) {
+        ir_MERGE_list(stack_overflow);
+        // JIT: printf("Stack overflow\n");
+        ir_CALL_1(IR_VOID, printf_func, ir_CONST_STR("Stack overflow\n"));
+        // JIT: pcpu->state = Cpu_Break;
+        ir_STORE(ir_ADD_OFFSET(cpu, offsetof(cpu_t, state)), ir_CONST_I32(Cpu_Break));
+        ir_RETURN(IR_VOID);
+    }
+
+    if (stack_underflow) {
+        ir_MERGE_list(stack_underflow);
+        // JIT: printf("Stack overflow\n");
+        ir_CALL_1(IR_VOID, printf_func, ir_CONST_STR("Stack underflow\n"));
+        // JIT: pcpu->state = Cpu_Break;
+        ir_STORE(ir_ADD_OFFSET(cpu, offsetof(cpu_t, state)), ir_CONST_I32(Cpu_Break));
+        ir_RETURN(IR_VOID);
+    }
+    if (stack_bound) {
+        ir_MERGE_list(stack_bound);
+        // JIT: printf("Out of bound picking\n");
+        ir_CALL_1(IR_VOID, printf_func, ir_CONST_STR("Stack underflow\n"));
+        // JIT: pcpu->state = Cpu_Break;
+        ir_STORE(ir_ADD_OFFSET(cpu, offsetof(cpu_t, state)), ir_CONST_I32(Cpu_Break));
+        ir_RETURN(IR_VOID);
+    }
+}
+
+int main(int argc, char **argv) {
+    uint64_t steplimit = parse_args(argc, argv);
+    cpu_t cpu = init_cpu();
+    ir_ctx ctx;
+    typedef void (*entry_t)(cpu_t*);
+    entry_t entry;
+    size_t size;
+
+    ir_init(&ctx, IR_FUNCTION | IR_OPT_FOLDING | IR_OPT_CFG | IR_OPT_CODEGEN, 256, 1024);
+
+    jit_program(&ctx, cpu.pmem, PROGRAM_SIZE);
+    ir_save(&ctx, IR_SAVE_CFG | IR_SAVE_RULES | IR_SAVE_REGS, stderr);
+
+    entry = (entry_t)ir_jit_compile(&ctx, 2, &size);
+    if (!entry) {
+        printf("Compilation failure\n");
+    }
+
+    ir_save(&ctx, IR_SAVE_CFG | IR_SAVE_RULES | IR_SAVE_REGS, stderr);
+    ir_disasm("prog", entry, size, 0, &ctx, stderr);
+
+    entry(&cpu);
+
+    ir_free(&ctx);
+
+    assert(cpu.state != Cpu_Running || cpu.steps == steplimit);
+
+    /* Print CPU state */
+    printf("CPU executed %ld steps. End state \"%s\".\n",
+            cpu.steps, cpu.state == Cpu_Halted? "Halted":
+                       cpu.state == Cpu_Running? "Running": "Break");
+    printf("PC = %#x, SP = %d\n", cpu.pc, cpu.sp);
+    printf("Stack: ");
+    for (int32_t i=cpu.sp; i >= 0 ; i--) {
+        printf("%#10x ", cpu.stack[i]);
+    }
+    printf("%s\n", cpu.sp == -1? "(empty)": "");
+
+    free(LoadedProgram);
+
+    return cpu.state == Cpu_Halted ||
+           (cpu.state == Cpu_Running &&
+            cpu.steps == steplimit)?0:1;
+}

--- a/jited_ir.c
+++ b/jited_ir.c
@@ -241,8 +241,8 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
     memset(jit->bb_sp, -1, len * sizeof(int));
 
 # ifdef JIT_USE_VARS
-	/* calculate stack_limit */
-	jit->stack_limit = 0;
+    /* calculate stack_limit */
+    jit->stack_limit = 0;
     decoded.opcode = Instr_Nop;
 
     for (int i=0; i < len;) {
@@ -311,12 +311,12 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
     }
 
     jit->sp = -1;
-	jit->vars = malloc(jit->stack_limit * sizeof(ir_ref));
-	for (int i = 0; i < jit->stack_limit; i++) {
-	    char s[16];
-	    sprintf(s, "t%d", i);
-	    jit->vars[i] = ir_var(_ir_CTX, IR_U32, 1, s);
-	}
+    jit->vars = malloc(jit->stack_limit * sizeof(ir_ref));
+    for (int i = 0; i < jit->stack_limit; i++) {
+        char s[16];
+        sprintf(s, "t%d", i);
+        jit->vars[i] = ir_var(_ir_CTX, IR_U32, 1, s);
+    }
 # endif
 #endif
 

--- a/jited_ir.c
+++ b/jited_ir.c
@@ -74,8 +74,8 @@ typedef struct _jit_label {
 } jit_label;
 
 typedef struct _jit_ctx {
-	ir_ctx     ctx;
-	ir_ref     cpu;
+    ir_ctx     ctx;
+    ir_ref     cpu;
 #ifdef JIT_RESOLVE_STACK
 # ifdef JIT_USE_VARS
     int        stack_limit;

--- a/jited_ir.c
+++ b/jited_ir.c
@@ -116,7 +116,7 @@ static ir_ref jit_pop(jit_ctx *jit) {
     assert(jit->sp >= 0);
     int sp = jit->sp--;
     //JIT: pcpu->stack[pcpu->sp--];
-    return ir_LOAD_I32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack) + sp * sizeof(uint32_t)));
+    return ir_LOAD_U32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack) + sp * sizeof(uint32_t)));
 #else
     // JIT: if (pcpu->sp < 0) {
     ir_ref sp_addr = ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, sp));
@@ -129,7 +129,7 @@ static ir_ref jit_pop(jit_ctx *jit) {
     ir_IF_FALSE(if_underflow);
 
     //JIT: pcpu->stack[pcpu->sp--];
-    ir_ref ret = ir_LOAD_I32(ir_ADD_I32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack)),
+    ir_ref ret = ir_LOAD_U32(ir_ADD_I32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack)),
             ir_MUL_I32(sp, ir_CONST_I32(sizeof(uint32_t)))));
     sp = ir_SUB_I32(sp, ir_CONST_I32(1));
     ir_STORE(sp_addr, sp);
@@ -148,7 +148,7 @@ static ir_ref jit_pick(jit_ctx *jit, ir_ref pos) {
 
     ir_IF_FALSE(if_out);
     // JIT: pcpu->stack[pcpu->sp - pos];
-    return ir_LOAD_I32(ir_ADD_I32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack)),
+    return ir_LOAD_U32(ir_ADD_I32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack)),
             ir_MUL_I32(ir_SUB_I32(ir_CONST_U32(jit->sp), pos), ir_CONST_I32(sizeof(uint32_t)))));
 #else
     // JIT: if (pcpu->sp - 1 < pos) {
@@ -160,7 +160,7 @@ static ir_ref jit_pick(jit_ctx *jit, ir_ref pos) {
 
     ir_IF_FALSE(if_out);
     // JIT: pcpu->stack[pcpu->sp - pos];
-    return ir_LOAD_I32(ir_ADD_I32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack)),
+    return ir_LOAD_U32(ir_ADD_I32(ir_ADD_OFFSET(jit->cpu, offsetof(cpu_t, stack)),
             ir_MUL_I32(ir_SUB_I32(sp, pos), ir_CONST_I32(sizeof(uint32_t)))));
 #endif
 }

--- a/jited_ir.c
+++ b/jited_ir.c
@@ -71,16 +71,25 @@ static inline decode_t decode_at_address(const Instr_t* prog, uint32_t addr) {
 typedef struct _jit_label {
     ir_ref inputs; /* number of input edges */
     ir_ref merge;  /* reference of MERGE or "list" of forward inputs */
+#if defined(JIT_RESOLVE_STACK) && defined(JIT_USE_SSA)
+    int    b;
+#endif
 } jit_label;
 
 typedef struct _jit_ctx {
     ir_ctx     ctx;
     ir_ref     cpu;
 #ifdef JIT_RESOLVE_STACK
-# ifdef JIT_USE_VARS
+# if defined(JIT_USE_SSA)
+    int        b;              /* current block */
+    int        blocks_count;
+    int        stack_limit;
+    ir_ref    *ssa_vars;
+    ir_ref    *incomplete_phis;
+# elif defined(JIT_USE_VARS)
     int        stack_limit;
     ir_ref    *vars;
-#endif
+# endif
     int        sp;
     int       *bb_sp; /* SP value at start of basic-block */
 #endif
@@ -93,10 +102,123 @@ typedef struct _jit_ctx {
 #undef  _ir_CTX
 #define _ir_CTX    (&jit->ctx)
 
+#ifdef JIT_USE_SSA
+static ir_ref jit_ssa_get_var(jit_ctx *jit, int b, int var, ir_ref control);
+
+static ir_ref jit_ssa_try_remove_trivial_phi(jit_ctx *jit, ir_ref phi) {
+    ir_ref i, n = jit->ctx.ir_base[phi].inputs_count;
+    ir_ref same, op;
+
+    assert(n > 2);
+    same = ir_get_op(_ir_CTX, phi, 2);
+    for (i = 3; i <= n; i++) {
+        op = ir_get_op(_ir_CTX, phi, i);
+        if (op != same && op != phi) {
+            return phi;
+        }
+    }
+
+    // Remember all users except the phi itself
+    // users = phi.users.remove(phi)
+    // Reroute all uses of phi to same and remove phi
+    // phi.replaceBy(same)
+    // Try to recursively remove all phi users, which might have become trivial
+    // for use in users: f use is a Phi: tryRemoveTrivialPhi(use)
+
+    return same;
+}
+
+static void jit_ssa_set_var(jit_ctx *jit, int b, int var, ir_ref val) {
+    jit->ssa_vars[var * jit->blocks_count + b] = val;
+}
+
+static ir_ref jit_ssa_get_var(jit_ctx *jit, int b, int var, ir_ref control) {
+    ir_ref val = jit->ssa_vars[var * jit->blocks_count + b];
+    ir_ref ref;
+    ir_insn *insn;
+
+    if (val) {
+        return val;
+    }
+
+    ref = control;
+    assert(ref);
+    insn = &jit->ctx.ir_base[ref];
+
+    /* go up to the start of basic-block through control links */
+    while (insn->op < IR_START || insn->op > IR_LOOP_BEGIN) {
+        ref = insn->op1;
+        insn = &jit->ctx.ir_base[ref];
+    }
+
+    assert(insn->op != IR_START);
+    if (insn->op == IR_MERGE || insn->op == IR_LOOP_BEGIN) {
+        bool incomplete = 0;
+        uint32_t i, n = insn->inputs_count;
+        val = ir_emit_N(_ir_CTX, IR_OPT(IR_PHI, IR_U32), n + 1);
+        ir_set_op(_ir_CTX, val, 1, ref);
+        jit->ssa_vars[var * jit->blocks_count + b] = val;
+        for (i = 1; i <= n; i++) {
+            ir_ref end = ir_get_op(_ir_CTX, ref, i);
+            if (end) {
+                ir_insn *end_insn = &jit->ctx.ir_base[end];
+                assert(end_insn->op >= IR_END && end_insn->op <= IR_SWITCH);
+                assert(end_insn->op3 >= 1000);
+                ir_ref op = jit_ssa_get_var(jit, end_insn->op3 - 1000, var, end);
+                ir_set_op(_ir_CTX, val, i + 1, op);
+            } else {
+                incomplete = 1;
+            }
+        }
+        if (incomplete) {
+            jit->incomplete_phis[var * jit->blocks_count + b] = val;
+        } else {
+            val = jit_ssa_try_remove_trivial_phi(jit, val);
+        }
+    } else {
+        ir_ref end = insn->op1;
+        assert(end);
+        ir_insn *end_insn = &jit->ctx.ir_base[end];
+        assert(end_insn->op >= IR_END && end_insn->op <= IR_SWITCH);
+        assert(end_insn->op3 >= 1000);
+        val = jit_ssa_get_var(jit, end_insn->op3 - 1000, var, end);
+    }
+	jit->ssa_vars[var * jit->blocks_count + b] = val;
+	return val;
+}
+
+static void jit_ssa_fix_incomplete_phis(jit_ctx *jit, uint32_t target)
+{
+    int dst_block = jit->labels[target].b;
+    int var;
+
+    for (var = 0; var < jit->stack_limit; var++) {
+        ir_ref phi = jit->incomplete_phis[var * jit->blocks_count + dst_block];
+        if (phi) {
+            ir_ref val = jit_ssa_get_var(jit, jit->b, var, jit->ctx.control);
+            ir_set_op(_ir_CTX, phi, jit->labels[target].inputs + 2, val);
+        }
+    }
+}
+
+static void jit_ssa_end_block(jit_ctx *jit) {
+    ir_ref end = jit->ctx.insns_count - 1;
+    ir_insn *insn = &jit->ctx.ir_base[end];
+    assert(insn->op >= IR_END && insn->op <= IR_SWITCH);
+    /* Use END->op3 to store the corresponding BB index */
+    insn->op3 = 1000 + jit->b;
+}
+
+#endif
+
 static void jit_push(jit_ctx *jit, ir_ref v) {
 #ifdef JIT_RESOLVE_STACK
     int sp = ++jit->sp;
-# ifdef JIT_USE_VARS
+# ifdef JIT_USE_SSA
+    assert(sp < jit->stack_limit);
+    // JIT: pcpu->stack[++pcpu->sp] = v;
+    jit_ssa_set_var(jit, jit->b, sp, v);
+# elif defined(JIT_USE_VARS)
     assert(sp < jit->stack_limit);
     // JIT: pcpu->stack[++pcpu->sp] = v;
     ir_VSTORE(jit->vars[sp], v);
@@ -128,7 +250,10 @@ static ir_ref jit_pop(jit_ctx *jit) {
 #ifdef JIT_RESOLVE_STACK
     int sp = jit->sp--;
     assert(sp >= 0);
-# ifdef JIT_USE_VARS
+# ifdef JIT_USE_SSA
+    // JIT: pcpu->stack[++pcpu->sp] = v;
+    return jit_ssa_get_var(jit, jit->b, sp, jit->ctx.control);
+# elif defined(JIT_USE_VARS)
     //JIT: pcpu->stack[pcpu->sp--];
     return ir_VLOAD_U32(jit->vars[sp]);
 # else
@@ -158,7 +283,12 @@ static ir_ref jit_pop(jit_ctx *jit) {
 
 static ir_ref jit_pick(jit_ctx *jit, ir_ref pos) {
 #ifdef JIT_RESOLVE_STACK
-# ifdef JIT_USE_VARS
+# ifdef JIT_USE_SSA
+    assert(IR_IS_CONST_REF(pos));
+    int sp = jit->ctx.ir_base[pos].val.i32;
+    assert(sp >= 0 && sp < jit->stack_limit);
+    return jit_ssa_get_var(jit, jit->b, sp, jit->ctx.control);
+# elif defined(JIT_USE_VARS)
     assert(IR_IS_CONST_REF(pos));
     int sp = jit->ctx.ir_base[pos].val.i32;
     assert(sp >= 0 && sp < jit->stack_limit);
@@ -191,10 +321,16 @@ static ir_ref jit_pick(jit_ctx *jit, ir_ref pos) {
 }
 
 static void jit_goto_backward(jit_ctx *jit, uint32_t target) {
+#if defined(JIT_RESOLVE_STACK) && defined(JIT_USE_SSA)
+    jit_ssa_fix_incomplete_phis(jit, target);
+#endif
     ir_set_op(_ir_CTX, jit->labels[target].merge, ++jit->labels[target].inputs, ir_END());
 #ifdef JIT_RESOLVE_STACK
     assert(jit->bb_sp[target] == -1 || jit->bb_sp[target] == jit->sp);
     jit->bb_sp[target] = jit->sp;
+# ifdef JIT_USE_SSA
+    jit_ssa_end_block(jit);
+# endif
 #endif
 }
 
@@ -203,6 +339,9 @@ static void jit_goto_forward(jit_ctx *jit, uint32_t target) {
 #ifdef JIT_RESOLVE_STACK
     assert(jit->bb_sp[target] == -1 || jit->bb_sp[target] == jit->sp);
     jit->bb_sp[target] = jit->sp;
+# ifdef JIT_USE_SSA
+    jit_ssa_end_block(jit);
+# endif
 #endif
 }
 
@@ -226,6 +365,17 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
         switch(decoded.opcode) {
         case Instr_JE:
         case Instr_JNE:
+#if defined(JIT_RESOLVE_STACK) && defined(JIT_USE_SSA)
+            if (!jit->labels[i + decoded.immediate].inputs && i + decoded.immediate != 0) {
+                jit->blocks_count++;
+            }
+            if (!jit->labels[i].inputs) {
+                jit->blocks_count++;
+            }
+#endif
+            jit->labels[i + decoded.immediate].inputs++;
+            jit->labels[i].inputs++;
+            break;
         case Instr_Jump:
             jit->labels[i + decoded.immediate].inputs++;
             break;
@@ -240,10 +390,15 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
     jit->bb_sp = malloc(len * sizeof(int));
     memset(jit->bb_sp, -1, len * sizeof(int));
 
-# ifdef JIT_USE_VARS
+# if defined(JIT_USE_SSA) || defined(JIT_USE_VARS)
     /* calculate stack_limit */
     jit->stack_limit = 0;
     decoded.opcode = Instr_Nop;
+
+#  ifdef JIT_USE_SSA
+    jit->blocks_count = 1;
+    jit->b = 0;
+#  endif
 
     for (int i=0; i < len;) {
         if (jit->labels[i].inputs > 0) {
@@ -253,6 +408,11 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
             }
             assert(jit->bb_sp[i] != -1);
             jit->sp == jit->bb_sp[i];
+#  ifdef JIT_USE_SSA
+            if (i != 0) {
+                jit->blocks_count++;
+            }
+#  endif
         }
 
         decoded = decode_at_address(prog, i);
@@ -311,12 +471,17 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
     }
 
     jit->sp = -1;
+#  ifdef JIT_USE_SSA
+    jit->ssa_vars = calloc(jit->stack_limit * jit->blocks_count, sizeof(ir_ref));
+    jit->incomplete_phis = calloc(jit->stack_limit * jit->blocks_count, sizeof(ir_ref));
+#  else
     jit->vars = malloc(jit->stack_limit * sizeof(ir_ref));
     for (int i = 0; i < jit->stack_limit; i++) {
         char s[16];
         sprintf(s, "t%d", i);
         jit->vars[i] = ir_var(_ir_CTX, IR_U32, 1, s);
     }
+#  endif
 # endif
 #endif
 
@@ -332,34 +497,50 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
     for (int i=0; i < len;) {
         if (jit->labels[i].inputs > 0) {
             if (decoded.opcode != Instr_Jump) {
-                jit->labels[i].inputs++;
+                if (decoded.opcode != Instr_JE
+                 && decoded.opcode != Instr_JNE) {
+                    jit->labels[i].inputs++;
+                }
                 jit_goto_forward(jit, i);
             }
+            assert(!jit->ctx.control);
+            if (jit->labels[i].inputs == 1) {
+                tmp3 = jit->labels[i].merge;
+                assert(tmp3);
+                ir_insn *insn = &jit->ctx.ir_base[tmp3];
+                assert(insn->op == IR_END && !insn->op2);
+                insn->op2 = IR_UNUSED;
+                ir_BEGIN(tmp3);
+                jit->labels[i].merge = IR_UNUSED;
+            } else {
+                tmp1 = ir_emit_N(_ir_CTX, IR_MERGE, jit->labels[i].inputs);
+                tmp2 = 0;
+                tmp3 = jit->labels[i].merge;
+                jit->labels[i].merge = jit->ctx.control = tmp1;
+
+                while (tmp3) {
+                    /* Store forward GOTOs into MERGE */
+                    tmp2++;
+                    assert(tmp2 <= jit->labels[i].inputs);
+                    ir_set_op(_ir_CTX, tmp1, tmp2, tmp3);
+                    ir_insn *insn = &jit->ctx.ir_base[tmp3];
+                    assert(insn->op == IR_END);
+                    tmp3 = insn->op2;
+                    insn->op2 = IR_UNUSED;
+                }
+                jit->labels[i].inputs = tmp2;
+            }
+
 #ifdef JIT_RESOLVE_STACK
             assert(jit->bb_sp[i] != -1);
             jit->sp == jit->bb_sp[i];
+# ifdef JIT_USE_SSA
+            if (i != 0) {
+                jit->b++;
+            }
+            jit->labels[i].b = jit->b;
+# endif
 #endif
-            assert(!jit->ctx.control);
-            if (jit->labels[i].inputs == 1) {
-                tmp1 = ir_emit1(_ir_CTX, IR_BEGIN, IR_UNUSED);
-            } else {
-                tmp1 = ir_emit_N(_ir_CTX, IR_MERGE, jit->labels[i].inputs);
-            }
-            tmp2 = 0;
-            tmp3 = jit->labels[i].merge;
-            jit->labels[i].merge = jit->ctx.control = tmp1;
-
-            while (tmp3) {
-                /* Store forward GOTOs into MERGE */
-                tmp2++;
-                assert(tmp2 <= jit->labels[i].inputs);
-                ir_set_op(_ir_CTX, tmp1, tmp2, tmp3);
-                ir_insn *insn = &jit->ctx.ir_base[tmp3];
-                assert(insn->op == IR_END);
-                tmp3 = insn->op2;
-                insn->op2 = IR_UNUSED;
-            }
-            jit->labels[i].inputs = tmp2;
         }
 
         decoded = decode_at_address(prog, i);
@@ -418,7 +599,9 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
             tmp2 = jit_pop(jit);
             // JIT if (tmp2 == 0)
             tmp3 = ir_IF(ir_EQ(tmp2, ir_CONST_U32(0)));
-
+#if defined(JIT_RESOLVE_STACK) && defined(JIT_USE_SSA)
+            jit_ssa_end_block(jit);
+#endif
             ir_IF_TRUE_cold(tmp3);
             // JIT: printf("Division by zero\n");
             ir_CALL_1(IR_VOID, printf_func, ir_CONST_STR("Division by zero\n"));
@@ -449,6 +632,9 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
             tmp1 = jit_pop(jit);
             // JIT: if (tmp1 == 0)
             tmp3 = ir_IF(ir_EQ(tmp1, ir_CONST_U32(0)));
+#if defined(JIT_RESOLVE_STACK) && defined(JIT_USE_SSA)
+            jit_ssa_end_block(jit);
+#endif
             ir_IF_TRUE(tmp3);
             if (decoded.immediate >= 0) {
                 jit_goto_forward(jit, i + decoded.immediate);
@@ -461,6 +647,9 @@ static void jit_program(jit_ctx *jit, const Instr_t *prog, int len) {
             tmp1 = jit_pop(jit);
             // JIT: if (tmp1 == 0)
             tmp3 = ir_IF(ir_NE(tmp1, ir_CONST_U32(0)));
+#if defined(JIT_RESOLVE_STACK) && defined(JIT_USE_SSA)
+            jit_ssa_end_block(jit);
+#endif
             ir_IF_TRUE(tmp3);
             if (decoded.immediate >= 0) {
                 jit_goto_forward(jit, i + decoded.immediate);

--- a/jited_ir.c
+++ b/jited_ir.c
@@ -570,15 +570,20 @@ int main(int argc, char **argv) {
     ir_init(&jit.ctx, IR_FUNCTION | IR_OPT_FOLDING | IR_OPT_CFG | IR_OPT_CODEGEN, 256, 1024);
 
     jit_program(&jit, cpu.pmem, PROGRAM_SIZE);
-    ir_save(&jit.ctx, IR_SAVE_CFG | IR_SAVE_RULES | IR_SAVE_REGS, stderr);
+
+    if (debug) {
+        ir_save(&jit.ctx, IR_SAVE_CFG | IR_SAVE_RULES | IR_SAVE_REGS, stderr);
+    }
 
     entry = (entry_t)ir_jit_compile(&jit.ctx, 2, &size);
     if (!entry) {
         printf("Compilation failure\n");
     }
 
-    ir_save(&jit.ctx, IR_SAVE_CFG | IR_SAVE_RULES | IR_SAVE_REGS, stderr);
-    ir_disasm("prog", entry, size, 0, &jit.ctx, stderr);
+    if (debug) {
+        ir_save(&jit.ctx, IR_SAVE_CFG | IR_SAVE_RULES | IR_SAVE_REGS, stderr);
+        ir_disasm("prog", entry, size, 0, &jit.ctx, stderr);
+    }
 
     entry(&cpu);
 

--- a/primes.php
+++ b/primes.php
@@ -1,0 +1,16 @@
+<?php
+function main() {
+    for ($i = 2; $i < 100000; $i++) {
+        $is_prime = true;
+        for ($divisor = 2; $divisor < $i; $divisor++) {
+            if ($i % $divisor == 0) {
+                $is_prime = false;
+                break;
+            }
+        }
+        if ($is_prime) {
+        	echo "[$i]\n";
+        }
+    }
+}
+main();


### PR DESCRIPTION
This adds JIT for your VM bytecode based on https://github.com/dstogov/ir
I just liked to check how IR framework does its work. The first naive version was 10 times slower than "native" code, but the obvious stack resolution made JIT-ed code almost as fast as "native" (~2-2.5% slower). The SSA construction removed even this gap.

It shouldn't be a big problem to port this to LLVM.  SSA construction should be done by "mem2reg" pass on top of "jitted_ir_var".

Also, I found that a weak-typed PHP interpreter is significantly faster than your best asm optimized version.
So it's definitely possible to write much faster interpreters...

@atakua you may be interested.

Benchmark Results
================
```
native                                   0.601
asmopt                                   2.986
predecoded                              21.943
subroutined                             15.425
switched                                24.787
tailrecursive                           14.670
threaded                                25.444
threaded-cached                         18.190
translated                              20.212

php -d opcache.enable=0                  2.188
php -d opcache.jit=0                     1.968
php -d opcache.jit=function              1.005
php -d opcache.jit=tracing               1.011

jited_ir                                 6.277
jited_ir_stack                           0.616
jited_ir_var                             0.613
jited_ir_ssa                             0.601
```